### PR TITLE
Add parser package with working imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # NYTXMLPARSE
-Mass Parse XML files
+
+Sample utilities to parse NYT-style XML files.
+
+```
+from nyt_xmlparse import NYTXMLParser
+
+parser = NYTXMLParser()
+root = parser.parse("<root></root>")
+print(root.tag)
+```

--- a/main.py
+++ b/main.py
@@ -1,0 +1,9 @@
+"""Example script using NYTXMLParser."""
+
+from nyt_xmlparse import NYTXMLParser
+
+if __name__ == "__main__":
+    parser = NYTXMLParser()
+    sample_xml = "<root><item>NYT</item></root>"
+    root = parser.parse(sample_xml)
+    print(root.tag)

--- a/nyt_xmlparse/__init__.py
+++ b/nyt_xmlparse/__init__.py
@@ -1,0 +1,5 @@
+"""NYT XML parsing utilities."""
+
+from .parser import NYTXMLParser
+
+__all__ = ["NYTXMLParser"]

--- a/nyt_xmlparse/parser.py
+++ b/nyt_xmlparse/parser.py
@@ -1,0 +1,11 @@
+"""Basic NYT XML parser stub."""
+
+from typing import Any
+import xml.etree.ElementTree as ET
+
+class NYTXMLParser:
+    """Simple parser for NYT-style XML files."""
+
+    def parse(self, xml_content: str) -> ET.Element:
+        """Parse XML string and return the root element."""
+        return ET.fromstring(xml_content)

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,7 @@
+from nyt_xmlparse import NYTXMLParser
+
+
+def test_import():
+    parser = NYTXMLParser()
+    xml = "<root></root>"
+    assert parser.parse(xml).tag == "root"


### PR DESCRIPTION
## Summary
- create a simple `nyt_xmlparse` package
- expose `NYTXMLParser` through package `__init__`
- demonstrate usage in `main.py`
- add README example
- add test to verify imports

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b8235312c832d9fc8a69daac240f5